### PR TITLE
Don't extend until constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,17 +36,17 @@
 /*global document,google */
 
 /**
- * @param {Function} childCtor Child class.
- * @param {Function} parentCtor Parent class.
+ * @param {Function} obj1 Child class.
+ * @param {Function} obj2 Parent class.
  */
-function inherits(childCtor, parentCtor) {
-  /** @constructor */
-  function tempCtor() {};
-  tempCtor.prototype = parentCtor.prototype;
-  childCtor.superClass_ = parentCtor.prototype;
-  childCtor.prototype = new tempCtor();
-  /** @override */
-  childCtor.prototype.constructor = childCtor;
+ MarkerLabel_.prototype.extend = function(obj1, obj2) {
+   return (function(object) {
+     for (var property in object.prototype) {
+       this.prototype[property] = object.prototype[property];
+     }
+     return this;
+   }).apply(obj1, [obj2]);
+ };
 }
 
 /**
@@ -59,6 +59,7 @@ function inherits(childCtor, parentCtor) {
  * @private
  */
 function MarkerLabel_(marker, crossURL, handCursorURL) {
+  this.extend(MarkerLabel_, google.maps.OverlayView);
   this.marker_ = marker;
   this.handCursorURL_ = marker.handCursorURL;
 
@@ -79,7 +80,6 @@ function MarkerLabel_(marker, crossURL, handCursorURL) {
   // Get the DIV for the "X" to be displayed when the marker is raised.
   this.crossDiv_ = MarkerLabel_.getSharedCross(crossURL);
 }
-inherits(MarkerLabel_, google.maps.OverlayView);
 
 /**
  * Returns the DIV for the cross used when dragging a marker when the
@@ -536,6 +536,7 @@ MarkerLabel_.prototype.setVisible = function () {
  * @param {MarkerWithLabelOptions} [opt_options] The optional parameters.
  */
 function MarkerWithLabel(opt_options) {
+  this.extend(MarkerWithLabel, google.maps.Marker);
   opt_options = opt_options || {};
   opt_options.labelContent = opt_options.labelContent || "";
   opt_options.labelAnchor = opt_options.labelAnchor || new google.maps.Point(0, 0);
@@ -569,7 +570,15 @@ function MarkerWithLabel(opt_options) {
   // that the marker label listens for in order to react to state changes.
   google.maps.Marker.apply(this, arguments);
 }
-inherits(MarkerWithLabel, google.maps.Marker);
+
+MarkerWithLabel.prototype.extend = function(obj1, obj2) {
+  return (function(object) {
+    for (var property in object.prototype) {
+      this.prototype[property] = object.prototype[property];
+    }
+    return this;
+  }).apply(obj1, [obj2]);
+};
 
 /**
  * Overrides the standard Marker setMap function.


### PR DESCRIPTION
This allows you to use require to include this without getting an error that `google` is not defined if it beats the Maps API to load (say you're loading it asynchronously or via https://www.npmjs.com/package/google-maps). It won't extend until the constructor.
