### PR TITLE
Fix content-security-policy violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ module.exports = function(gMapsApi) {
     this.eventDiv_.style.cssText = this.labelDiv_.style.cssText;
 
     // This is needed for proper behavior on MSIE:
-    this.eventDiv_.setAttribute("onselectstart", "return false;");
-    this.eventDiv_.setAttribute("ondragstart", "return false;");
+    this.eventDiv_.addEventListener('selectstart', function() { return false; });
+    this.eventDiv_.addEventListener('dragstart', function() { return false; });
 
     // Get the DIV for the "X" to be displayed when the marker is raised.
     this.crossDiv_ = MarkerLabel_.getSharedCross(crossURL);


### PR DESCRIPTION
In Firefox, when using a content-security-policy that does not allow `unsafe-inline` script sources, the `setAttribute` calls below trigger CSP violations. This change updates those lines to use `addEventListener` instead.